### PR TITLE
Incorrect CPU Timer - Now Corrected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ autoconf/compile
 allTests.*
 
 # Dynamically generated files
+/_nmake_pjj.bat

--- a/clock.c
+++ b/clock.c
@@ -372,16 +372,15 @@ static void adjust_tod_offset(const S64 offset)
 TOD
 thread_cputime(const REGS *regs)
 {
-    register TOD    result;
+    TOD             result;
+    int             rc = -1;
+    struct timespec cputime;
 
-    struct rusage   rusage;
-    int             rc;
-
-    rc = getrusage((int)sysblk.cputid[regs->cpuad], &rusage);
-    if (unlikely(rc == -1))
-        result = host_tod();
-    else
-        result  = timeval2etod(&rusage.ru_utime);
+    if (sysblk.cpuclockid[regs->cpuad])
+    {
+        rc = clock_gettime(sysblk.cpuclockid[regs->cpuad], &cputime);
+    }
+    result = (likely(rc == 0)) ? timespec2etod(&cputime) : host_tod();
 
     return (result);
 }
@@ -391,15 +390,14 @@ U64
 thread_cputime_us(const REGS *regs)
 {
     U64 result;
+    int             rc = -1;
+    struct timespec cputime;
 
-    struct rusage   rusage;
-    int             rc;
-
-    rc = getrusage((int)sysblk.cputid[regs->cpuad], &rusage);
-    if (unlikely(rc == -1))
-        result = etod2us(host_tod());
-    else
-        result  = timeval2us(&rusage.ru_utime);
+    if (sysblk.cpuclockid[regs->cpuad])
+    {
+        rc = clock_gettime(sysblk.cpuclockid[regs->cpuad], &cputime);
+    }
+    result = (likely(rc == 0)) ? timespec2us(&cputime) : etod2us(host_tod());
 
     return (result);
 }

--- a/clock.h
+++ b/clock.h
@@ -333,7 +333,7 @@ us2timeval (const U64 us, struct timeval* tv)
 static INLINE TOD
 ns2etod (const S64 ns)
 {
-    return ((ns << 9) / 125);           /* (ns << 8) / 1000           */
+    return ((ns << 1) / 125);           /* (ns << 4) / 1000      @PJJ */
 }
 
 static INLINE TOD
@@ -674,6 +674,12 @@ timeval2tod (const struct timeval* tv)
     result  = sec2tod(tv->tv_sec);
     result += us2tod(tv->tv_usec);
     return (result);
+}
+
+static INLINE S64
+timespec2us (const struct timespec* ts)
+{
+    return ((ts->tv_sec) * 1000000 + ((ts->tv_nsec + 500) / 1000));
 }
 
 

--- a/config.c
+++ b/config.c
@@ -1056,6 +1056,9 @@ int configure_cpu( int target_cpu )
             return HERRCPUOFF; /* CPU offline; create_thread failed */
         }
 
+    /* Initialise the CPU's thread clockid so that clock_gettime() can use it */
+    pthread_getcpuclockid(sysblk.cputid[ target_cpu ], &sysblk.cpuclockid[ target_cpu ]);
+
         /* Find out if we are a cpu thread */
         arecpu = are_cpu_thread( &ourcpu );
 
@@ -1131,6 +1134,7 @@ int deconfigure_cpu( int target_cpu )
         }
 
         sysblk.cputid[ target_cpu ] = 0;
+        sysblk.cpuclockid[ target_cpu ] = 0;
 
 #if defined( FEATURE_CONFIGURATION_TOPOLOGY_FACILITY )
         /* Set topology-change-report-pending condition */

--- a/hstructs.h
+++ b/hstructs.h
@@ -193,8 +193,9 @@ struct REGS {                           /* Processor registers       */
         U64     siototal;               /* Total SIO/SSCH count      */
                                         /* --- 64-byte cache line -- */
         int     cpupct;                 /* Percent CPU busy          */
-        U64     waittod;                /* Time of day last wait (us)*/
-        U64     waittime;               /* Wait time (us) in interval*/
+        U64     waittod;                /* Time of day last wait     */
+        U64     waittime;               /* Wait time in interval     */
+        U64     waittime_accumulated;   /* Wait time accumulated     */
 
         CACHE_ALIGN                     /* --- 64-byte cache line -- */
         DAT     dat;                    /* Fields for DAT use        */
@@ -530,6 +531,8 @@ struct SYSBLK {
         LOCK    cpulock[MAX_CPU_ENGINES];  /* CPU lock               */
         TOD     cpucreateTOD[MAX_CPU_ENGINES];  /* CPU creation time */
         TID     cputid[MAX_CPU_ENGINES];   /* CPU thread identifiers */
+        clockid_t                              /* CPU clock     @PJJ */
+                cpuclockid[MAX_CPU_ENGINES];   /* identifiers   @PJJ */
         BYTE    ptyp[MAX_CPU_ENGINES];  /* SCCB ptyp for each engine */
         LOCK    todlock;                /* TOD clock update lock     */
         TID     todtid;                 /* Thread-id for TOD update  */

--- a/timer.c
+++ b/timer.c
@@ -260,6 +260,7 @@ const U64   period = ETOD_SEC;          /* MIPS calculation period   */
 
                 /* Calculate CPU busy percentage */
                 waittime = regs->waittime;
+                regs->waittime_accumulated += waittime;
                 regs->waittime = 0;
                 if (regs->waittod)
                 {

--- a/w32util.c
+++ b/w32util.c
@@ -469,6 +469,29 @@ DLL_EXPORT int clock_gettime ( clockid_t clk_id, struct timespec *tp )
         return -1;
     }
 
+
+
+    // Simulate clock_gettime with a clk_id as set by pthread_getcpuclockid,
+    // which is simply mines the thread_id, i.e. clk_id = -tid.              (PJJ Jan-2018)
+    if ( clk_id < 0 )
+    {
+        struct rusage r_usage;
+        int           result;
+
+        result = getrusage( -clk_id, &r_usage );
+        tp->tv_sec   = r_usage.ru_utime.tv_sec;
+        tp->tv_nsec  = r_usage.ru_utime.tv_usec;
+        tp->tv_sec  += r_usage.ru_stime.tv_sec;
+        tp->tv_nsec += r_usage.ru_stime.tv_usec;
+        if (tp->tv_nsec > 1000000)
+        {
+            tp->tv_sec += tp->tv_nsec / 1000000;
+            tp->tv_nsec = tp->tv_nsec % 1000000;
+        }
+        tp->tv_nsec *= 1000;
+        return result;
+    }
+
     while (1) { // (for easy backward branching)
 
     // Query current high-performance counter value...
@@ -613,6 +636,18 @@ DLL_EXPORT int clock_gettime ( clockid_t clk_id, struct timespec *tp )
     // Done!
 
     return 0;       // (always, unless user error)
+}
+
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// In Windows, thread specific timings can be obtained directly from the thread_id (tid),
+// but under Linux etc. a clock_id must be derived first from that thread_id.  Having
+// observed that such clock_id's are negative, we just simulate the clock_id as -tid.
+//                                                                           (PJJ Jan-2018)
+DLL_EXPORT int pthread_getcpuclockid ( TID tid, clockid_t* clk_id )
+{
+    *clk_id = -tid;
+    return 0;
 }
 
 

--- a/w32util.h
+++ b/w32util.h
@@ -134,6 +134,7 @@ W32_DLL_IMPORT char* strtok_r ( char* s, const char* sep, char** lasts);
     struct timeval  ru_stime;       // System time used
   };
   W32_DLL_IMPORT int getrusage ( int who, struct rusage* r_usage );
+  W32_DLL_IMPORT int pthread_getcpuclockid ( TID tid, clockid_t* clk_id );
 #endif
 
 #if !defined(HAVE_DECL_LOGIN_NAME_MAX) || !HAVE_DECL_LOGIN_NAME_MAX


### PR DESCRIPTION
The issue was first described by Peter Coghlan (as Issue #217 in the official Hyperion GitHub), and has now been solved along the lines as initially described by Mark "dasdman" L. Gaubatz, and commented on by Ivan, John, and Fish (all of which can be read up on GitHub).

The solution as described by Mark needed some amendments, and required some extra problems to be solved.  These included :

 (1) Mark's original getrusage() produced two statistics : thread user time, and thread system time.  Fish's Windows equivalent implementation for getrusage() supplies the Windows thread user and kernel times for these.  Only when running under Windows does the Hercules qproc command correctly show these CPU thread user and kernel times.  This qproc behavior has been retained as is.

 (2) The clock_gettime() replacement for getrusage() has been mentioned on the 'net to produce the sum of both user and system time.  I have assumed that this is correct, even though I'd like further confirmation this to be correct.  The Windows clock_gettime() equivalent for thread CPU time therefore returns the sum of the Windows user and kernel times.

 (3) The original "diagmssf.c" code for DIAG 204 delivered the VM virtual CPU time as the getrusage() user time (uCPU); the VM total CPU time (tCPU) was computed as the sum of the getrusage() user+system time; the VM wait time (wCPU) was computed as the difference tCPU-uCPU.  This would imply that the VM wait time equals the getrusage() system time.  I don't think that is correct.  In order to correct this I have added and computed regs->waittime_accumulated in "timer.c" to set wCPU. (This requires OPTION_MIPS_COUNTING to be #defined, but after inspection, I think that is already implicitly required anyway in other places.)  With uCPU set to clock_gettime() thread user+system time, tCPU is now computed as uCPU+wCPU. I believe this delivers the more accurate DIAG 204 data.

 (4) The clock_gettime() for thread user+system CPU time needs the thread clockid.  Following the thinking as voiced by Ivan and John, I've added sysblk.cpuclockid[cpu] so that only one pthread_getcpuclockid() call per CPU thread is needed.

 (5) The Windows equivalent for thread clockid simulates this as the negative of the thread_id, and the clock_gettime() equivalent then uses this negative to call the existing Windows getrusage() to obtain and sum the Windows thread user and kernel times.  Fish may wish to improve or beautify this simple but straightforward concept.